### PR TITLE
fix(about): start survey button

### DIFF
--- a/lib/features/about/about.dart
+++ b/lib/features/about/about.dart
@@ -7,7 +7,8 @@ import 'about_data.dart';
 import 'principle.dart';
 
 class AboutPage extends StatefulWidget {
-  const AboutPage({Key key}) : super(key: key);
+  final Function() onTakeSurveyPressed;
+  const AboutPage({Key key, this.onTakeSurveyPressed}) : super(key: key);
 
   @override
   _AboutPageState createState() => _AboutPageState();
@@ -139,26 +140,6 @@ class _AboutPageState extends State<AboutPage> {
                         }));
                       },
                     );
-                    //  return Container(
-                    //   width: 150,
-                    //   height: 55,
-                    //   child: GestureDetector(
-                    //      onTap: () {
-                    //       Navigator.push(context, MaterialPageRoute(
-                    //             builder: (BuildContext context) {
-                    //           return Principle(
-                    //             logo: principle['logo'],
-                    //             title: principle['title'],
-                    //             text: principle['text'],
-                    //           );
-                    //         }));
-                    //       },
-                    //      child: Image(
-                    //        image: AssetImage(principle['image']),
-                    //        fit: BoxFit.fill,
-                    //       ),
-                    //     ),
-                    //  );
                   }).toList(),
                 ),
               ),
@@ -173,7 +154,7 @@ class _AboutPageState extends State<AboutPage> {
                     shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(40)),
                     color: AppColors.orange,
-                    onPressed: () {},
+                    onPressed: widget.onTakeSurveyPressed,
                     child: Text(
                       S.of(context).takeSurvey,
                       textAlign: TextAlign.center,

--- a/lib/features/tab_bar_controller.dart
+++ b/lib/features/tab_bar_controller.dart
@@ -7,7 +7,6 @@ import 'home/home_page_content/home_page.dart';
 import '../shared_ui_elements/colors.dart';
 
 class TabBarController extends StatefulWidget {
-
   @override
   _TabBarControllerState createState() => _TabBarControllerState();
 }
@@ -22,7 +21,11 @@ class _TabBarControllerState extends State<TabBarController> {
 
   int pageIndex = 0;
 
-  List<Widget> _pages = [HomePage(), AboutPage()];
+  void _animateToPage(int index) {
+    setState(() {
+      pageIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,11 +33,7 @@ class _TabBarControllerState extends State<TabBarController> {
       bottomNavigationBar: BottomNavigationBar(
         selectedItemColor: AppColors.darkBlue,
         backgroundColor: AppColors.greyAboutPage,
-        onTap: (int index) {
-          setState(() {
-            pageIndex = index;
-          });
-        },
+        onTap: _animateToPage,
         currentIndex: pageIndex,
         items: [
           BottomNavigationBarItem(
@@ -47,7 +46,16 @@ class _TabBarControllerState extends State<TabBarController> {
           ),
         ],
       ),
-      body: _pages[pageIndex],
+      body: _getPage(),
     );
+  }
+
+  Widget _getPage() {
+    switch (pageIndex) {
+      case 0:
+        return HomePage();
+      default:
+        return AboutPage(onTakeSurveyPressed: () => _animateToPage(0));
+    }
   }
 }


### PR DESCRIPTION
closes #42 

@Jerome-Clement @odhlen @andreasts 
Since on the homepage we check if the survey exists or not/needs to be completed or started, I made the button in the about redirect to the homepage. We can merge this change. However, other options we have:
1. remove the button.
2. make it identical to the homepage. However, this option will be a lot of refactoring and it will take some time and we will need to test again.

<img src="http://g.recordit.co/2iVFQh3bqx.gif" width=50% height=50%/>