### PR TITLE
Feat || 52 || Configuring Firebase Messaging

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,7 @@ if (flutterVersionName == null) {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
@@ -60,4 +61,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.google.firebase:firebase-messaging:21.0.1'
 }

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "39173011454",
+    "project_id": "libertaspeople-d7db6",
+    "storage_bucket": "libertaspeople-d7db6.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:39173011454:android:ab26dedf6e9c24569172af",
+        "android_client_info": {
+          "package_name": "com.slavefreetrade.libertaspeople"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "39173011454-8q8ojmdkdd4caap7v0v2bhn200l8v1pn.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAhYDUacg1kssbraDy0ByXzwwdvPfcZSL8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "39173011454-8q8ojmdkdd4caap7v0v2bhn200l8v1pn.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,12 +31,16 @@
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
             <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
+                android:name="io.flutter.embedding.android.SplashScreenDrawable"
+                android:resource="@drawable/launch_background" />
+
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="FLUTTER_NOTIFICATION_CLICK" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-todo_practice_work.data below.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.2'
     }
 }
 

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../../data_layer/repository.dart';
 import '../../features/privacyPolicyAndTerms/privacy_policy_page.dart';
 import '../../generated/l10n.dart';
+import '../../services/notification_service.dart';
 import '../../shared_ui_elements/buttons/button_orange_color.dart';
 import '../../shared_ui_elements/colors.dart';
 import '../../shared_ui_elements/images.dart';
@@ -35,6 +36,12 @@ class _OnboardingPageState extends State<OnboardingPage> {
         builder: (context) => const PrivacyPolicyPage(
               shouldShowAccept: true,
             )));
+  }
+
+  @override
+  void initState() {
+    NotificationService().subscribeToOnBoardingNotCompletedNotification();
+    super.initState();
   }
 
   @override

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -874,10 +874,8 @@ class AppLocalizationDelegate extends LocalizationsDelegate<S> {
 
   @override
   bool isSupported(Locale locale) => _isSupported(locale);
-
   @override
   Future<S> load(Locale locale) => S.load(locale);
-
   @override
   bool shouldReload(AppLocalizationDelegate old) => false;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+
 import 'package:libertaspeople/features/home/home_cubit.dart';
 import 'package:libertaspeople/features/survey/survey_cubit.dart';
 import 'package:libertaspeople/shared_ui_elements/shared_ui_elements.dart';
@@ -8,7 +11,10 @@ import 'features/splash_screen.dart';
 import 'generated/l10n.dart';
 import 'shared_ui_elements/colors.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+
   runApp(MyApp());
 }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,66 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+
+class NotificationService extends NotificationServiceI {
+  @override
+  Future<void> subscribeToSurveyNotOpenedNotification() async {
+    await Future.wait([
+      FirebaseMessaging.instance
+          .subscribeToTopic(_NotificationTopic.surveyNotOpened),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyNotCompleted),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyCompleted),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.onBoardingNotCompleted),
+    ], eagerError: true);
+  }
+
+  @override
+  Future<void> subscribeToSurveyNotCompletedNotification() async {
+    await Future.wait([
+      FirebaseMessaging.instance
+          .subscribeToTopic(_NotificationTopic.surveyNotCompleted),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyNotOpened),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyCompleted),
+    ], eagerError: true);
+  }
+
+  @override
+  Future<void> subscribeToSurveyCompletedNotification() async {
+    await Future.wait([
+      FirebaseMessaging.instance
+          .subscribeToTopic(_NotificationTopic.surveyCompleted),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyNotCompleted),
+      FirebaseMessaging.instance
+          .unsubscribeFromTopic(_NotificationTopic.surveyNotOpened),
+    ], eagerError: true);
+  }
+
+  @override
+  Future<void> subscribeToOnBoardingNotCompletedNotification() async {
+    await Future.wait([
+      FirebaseMessaging.instance
+          .subscribeToTopic(_NotificationTopic.onBoardingNotCompleted),
+    ], eagerError: true);
+  }
+}
+
+abstract class NotificationServiceI {
+  Future<void> subscribeToSurveyNotOpenedNotification();
+
+  Future<void> subscribeToSurveyNotCompletedNotification();
+
+  Future<void> subscribeToSurveyCompletedNotification();
+
+  Future<void> subscribeToOnBoardingNotCompletedNotification();
+}
+
+class _NotificationTopic {
+  static const String surveyNotCompleted = 'survey_not_completed';
+  static const String surveyCompleted = 'survey_completed';
+  static const String surveyNotOpened = 'survey_not_opened';
+  static const String onBoardingNotCompleted = 'on_boarding_not_completed';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: libertaspeople
 description: Human rights surveying app
 
 publish_to: "none"
-version: 0.1.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,11 @@ environment:
 
 dependencies:
   device_info: ^1.0.0
+  firebase_messaging: ^7.0.3
   flutter:
     sdk: flutter
   flutter_bloc: ^6.1.1
+  flutter_local_notifications: ^4.0.0
   flutter_secure_storage: ^3.3.4
   flutter_svg: ^0.18.0
   http: ^0.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 
 dependencies:
   device_info: ^1.0.0
-  firebase_messaging: ^7.0.3
+  firebase_core: ^0.7.0
+  firebase_messaging: ^8.0.0-dev.14
   flutter:
     sdk: flutter
   flutter_bloc: ^6.1.1
-  flutter_local_notifications: ^4.0.0
   flutter_secure_storage: ^3.3.4
   flutter_svg: ^0.18.0
   http: ^0.12.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: libertaspeople
 description: Human rights surveying app
 
 publish_to: "none"
-version: 0.2.1+1
+version: 0.2.1+2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
closes #52

Here are some points I noticed while testing we might need to clarify:
1. If the notification arrives and the app is in the foreground, the notification will be dismissed.
2. If you choose from the timer at the beginning of a survey every say 2 minutes, it won't work as expected in the second survey. That is because the notification is triggered only once per user every 7 days. 7 days specifically because we configured it as such on Cloud Messaging; we can decrease it if you want. So if it is displayed one time, it won't display again until a week after.